### PR TITLE
Fix TaxJar order submissions

### DIFF
--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -40,7 +40,7 @@ module SuperGood
         def tax_amount(order)
           # Sum of line items + shipping, excluding tax
           line_items_total = order.line_items.sum do |line_item|
-            quantity = taxable_quantity(line_item)
+            quantity = line_item.quantity
             unit_price = SuperGood::SolidusTaxjar.line_item_unit_price_calculator.call(line_item)
             quantity * unit_price
           end
@@ -67,10 +67,8 @@ module SuperGood
               sales_tax: sales_tax(order)
             )
 
-          if order.user
-            customer_info = user_params(order.user)
-            params.merge!(customer_info)
-          end
+          customer_info = user_params(order&.bill_address)
+          params.merge!(customer_info)
 
           params
         end
@@ -123,21 +121,20 @@ module SuperGood
           params
         end
 
-        def user_params(user)
-          address = user.addresses.first
-
+        def user_params(address)
+          return {} if address.nil?
+          
           {
             customer_info: {
-              customer_id: user.id,
+              customer_id: address.user_id&.to_s,
               name: address.company.present? ? address.company : address.name,
               country: address.country.iso,
-              state: address.state.abbr,
+              state: address.state&.abbr || address.state_name,
               zip: address.zipcode,
               city: address.city,
               street: address.address1,
-              exempt_regions: user.taxjar_exempt_regions.approved.map do |exempt_region|
+              exempt_regions: address.user&.taxjar_exempt_regions&.approved&.map do |exempt_region|
                 state = exempt_region.state
-
                 {
                   state: state.abbr,
                   country: state.country.iso
@@ -223,7 +220,7 @@ module SuperGood
         def transaction_line_items_params(line_items)
           {
             line_items: line_items.filter_map { |line_item|
-              quantity = taxable_quantity line_item
+              quantity = line_item.quantity
               next unless quantity.positive?
 
               {

--- a/lib/super_good/solidus_taxjar/api_params.rb
+++ b/lib/super_good/solidus_taxjar/api_params.rb
@@ -37,9 +37,24 @@ module SuperGood
           }.merge(order_address_params(address))
         end
 
+        def tax_amount(order)
+          # Sum of line items + shipping, excluding tax
+          line_items_total = order.line_items.sum do |line_item|
+            quantity = taxable_quantity(line_item)
+            unit_price = SuperGood::SolidusTaxjar.line_item_unit_price_calculator.call(line_item)
+            quantity * unit_price
+          end
+          shipping_total = order.ship_total || 0
+
+          # Calculate total before tax
+          subtotal = line_items_total + shipping_total
+
+          # Ensure non-negative amount
+          [subtotal, 0].max
+        end
+
         def transaction_params(order, transaction_id = order.number)
-          {}
-            .merge(customer_id(order))
+          params = {}.merge(customer_id(order))
             .merge(order_address_params(order.tax_address))
             .merge(transaction_line_items_params(order.line_items))
             .merge(
@@ -47,10 +62,17 @@ module SuperGood
               transaction_date: order.completed_at.to_formatted_s(:iso8601),
               # We use `payment_total` to reflect the total liablity
               # transferred.
-              amount: [order.payments.completed.sum(&:amount) - refund_total_without_tax(order) - order.additional_tax_total, 0].max,
+              amount: tax_amount(order),
               shipping: shipping(order),
               sales_tax: sales_tax(order)
             )
+
+          if order.user
+            customer_info = user_params(order.user)
+            params.merge!(customer_info)
+          end
+
+          params
         end
 
         def refund_transaction_params(spree_order, taxjar_order)
@@ -99,6 +121,30 @@ module SuperGood
           }
           params[:street] = [spree_address.address1, spree_address.address2].compact.join(' ') if include_street
           params
+        end
+
+        def user_params(user)
+          address = user.addresses.first
+
+          {
+            customer_info: {
+              customer_id: user.id,
+              name: address.company.present? ? address.company : address.name,
+              country: address.country.iso,
+              state: address.state.abbr,
+              zip: address.zipcode,
+              city: address.city,
+              street: address.address1,
+              exempt_regions: user.taxjar_exempt_regions.approved.map do |exempt_region|
+                state = exempt_region.state
+
+                {
+                  state: state.abbr,
+                  country: state.country.iso
+                }
+              end
+            }
+          }
         end
 
         def customer_params(customer)


### PR DESCRIPTION
### Description
This fixes the amount must be equal to the sum of line items + shipping, excluding tax error. The error might have been because the amount is calculated using order payments and  in this [commit](https://github.com/printivity/solidus_taxjar/commit/99bfe75299872b92104bfec74c69818db07754c4) the report is triggered when the shipment is shipped and maybe the payment hasn't been completed yet.
